### PR TITLE
remove upperdir and workdir before mounting

### DIFF
--- a/types/molecule.go
+++ b/types/molecule.go
@@ -102,6 +102,8 @@ func (m Molecule) OverlayArgs(dest string, writable bool) (string, error) {
 		upperDir := m.config.OverlayDirsPath(sha256string(dest), "upperdir")
 		workDir := m.config.OverlayDirsPath(sha256string(dest), "workdir")
 
+		os.RemoveAll(workDir)
+		os.RemoveAll(upperdir)
 		if err := os.MkdirAll(upperDir, 0755); err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Otherwise upon a umount/remount we see the previous mount's changes
reflected in the new dir.

Signed-off-by: Serge Hallyn <shallyn@cisco.com>