### PR TITLE
mount/types.go: always mount squasfs as readonly

### DIFF
--- a/mount/types.go
+++ b/mount/types.go
@@ -27,7 +27,7 @@ func mountSquashfs(source string, dest string) error {
 	}
 	defer dev.Detach()
 
-	err = unix.Mount(dev.Path(), dest, "squashfs", 0, "")
+	err = unix.Mount(dev.Path(), dest, "squashfs", unix.MS_RDONLY, "")
 	return errors.Wrapf(err, "couldn't mount %s to %s", source, dest)
 }
 


### PR DESCRIPTION
Signed-off-by: Serge Hallyn <shallyn@cisco.com>