### PR TITLE
mount/types.go: tell go-losetup to attach readonly

### DIFF
--- a/mount/types.go
+++ b/mount/types.go
@@ -21,7 +21,7 @@ func mountTar(source string, dest string) error {
 }
 
 func mountSquashfs(source string, dest string) error {
-	dev, err := losetup.Attach(source, 0, false)
+	dev, err := losetup.Attach(source, 0, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The third argument to losetup.Attach() is 'readonly'.  If that's
false, then it will open the file O_RDWR.  So make it true.

Signed-off-by: Serge Hallyn <shallyn@cisco.com>